### PR TITLE
chore!: update eol sso

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -3,6 +3,7 @@
 set -e
 
 pip install --src /openedx/venv/src -e git+https://github.com/eol-uchile/uchileedxlogin@1.0.0#egg=uchileedxlogin
+pip install --src /openedx/venv/src -e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso
 pip install --src /openedx/venv/src -e /openedx/requirements/app
 pip install pytest-cov genbadge[coverage]
 

--- a/eol_report_analytics/tests.py
+++ b/eol_report_analytics/tests.py
@@ -101,14 +101,14 @@ class TestEolReportAnalyticsView(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(request['PATH_INFO'], '/eol_report_analytics/data')
     
-    @patch("eol_report_analytics.views.get_user_id_doc_id_pairs")
+    @patch("eol_report_analytics.views.get_user_id_with_indiv_id_list")
     @patch("eol_report_analytics.views.modulestore")
     @patch("eol_report_analytics.views.EolReportAnalyticsView.get_report_xblock")
-    def test_eol_report_analytics_get_all_data(self, report, store_mock, mock_user_id_doc_id_pairs):
+    def test_eol_report_analytics_get_all_data(self, report, store_mock, mock_user_id_with_indiv_id_list):
         """
             Test eol_report_analytics view data
         """
-        mock_user_id_doc_id_pairs.return_value = [(self.student.id, '09472337K')]
+        mock_user_id_with_indiv_id_list.return_value = [(self.student.id, '09472337K')]
         u1_state_1 = {_("Answer ID"): 'answer_id_1',
             _("Question"): 'question_text_1',
             _("Answer"): 'correct_answer_text_1',
@@ -194,35 +194,35 @@ class TestEolReportAnalyticsView(ModuleStoreTestCase):
             ]
         self._verify_csv_file_report(report_store, expected_data)
 
-    @patch("eol_report_analytics.views.get_user_id_doc_id_pairs")
-    def test_get_enrolled_users_with_doc_id(self, mock_user_id_doc_id_pairs):
+    @patch("eol_report_analytics.views.get_user_id_with_indiv_id_list")
+    def test_get_enrolled_users_with_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-            Test that doc_id is being added correctly to enrolled users, in the case when one of the
-            students has a doc_id associated to it.
+            Test that indiv_id is being added correctly to enrolled users, in the case when one of the
+            students has a indiv_id associated to it.
         """
-        mock_user_id_doc_id_pairs.return_value = [(self.student.id, '09472337K')]
+        mock_user_id_with_indiv_id_list.return_value = [(self.student.id, '09472337K')]
         enrolled_users = EolReportAnalyticsView().get_all_enrolled_users(self.course.id)
-        self.assertEqual(enrolled_users[self.student.username]['doc_id'], '09472337K')
-        self.assertEqual(enrolled_users[self.student2.username]['doc_id'], '')
+        self.assertEqual(enrolled_users[self.student.username]['indiv_id'], '09472337K')
+        self.assertEqual(enrolled_users[self.student2.username]['indiv_id'], '')
 
-    @patch("eol_report_analytics.views.get_user_id_doc_id_pairs")
-    def test_get_enrolled_users_without_doc_id(self, mock_user_id_doc_id_pairs):
+    @patch("eol_report_analytics.views.get_user_id_with_indiv_id_list")
+    def test_get_enrolled_users_without_indiv_id(self, mock_user_id_with_indiv_id_list):
         """
-            Test that doc_id is being set correctly in the case when no user has a doc_id associated.
+            Test that indiv_id is being set correctly in the case when no user has a indiv_id associated.
         """
-        mock_user_id_doc_id_pairs.return_value = []
+        mock_user_id_with_indiv_id_list.return_value = []
         enrolled_users = EolReportAnalyticsView().get_all_enrolled_users(self.course.id)
-        self.assertEqual(enrolled_users[self.student.username]['doc_id'], '')
-        self.assertEqual(enrolled_users[self.student2.username]['doc_id'], '')
+        self.assertEqual(enrolled_users[self.student.username]['indiv_id'], '')
+        self.assertEqual(enrolled_users[self.student2.username]['indiv_id'], '')
 
-    @patch("eol_report_analytics.views.get_user_id_doc_id_pairs")
+    @patch("eol_report_analytics.views.get_user_id_with_indiv_id_list")
     @patch("eol_report_analytics.views.modulestore")
     @patch("eol_report_analytics.views.EolReportAnalyticsView.get_report_xblock")
-    def test_eol_report_analytics_get_all_data_correct(self, report, store_mock, mock_user_id_doc_id_pairs):
+    def test_eol_report_analytics_get_all_data_correct(self, report, store_mock, mock_user_id_with_indiv_id_list):
         """
             Test eol_report_analytics view data
         """
-        mock_user_id_doc_id_pairs.return_value = []
+        mock_user_id_with_indiv_id_list.return_value = []
         u1_state_1 = {_("Answer ID"): 'answer_id_1',
             _("Question"): 'question_text_1',
             _("Answer"): 'correct_answer_text_1',

--- a/eol_report_analytics/views.py
+++ b/eol_report_analytics/views.py
@@ -24,7 +24,7 @@ from django.urls import reverse
 from django.utils.translation import gettext as _, ugettext_noop
 from django.views.generic.base import View
 from pytz import UTC
-from uchileedxlogin.services.interface import get_user_id_doc_id_pairs
+from eol_sso.services.interface import get_user_id_with_indiv_id_list
 
 # Edx dependencies
 from common.djangoapps.util.file import course_filename_prefix_generator
@@ -500,7 +500,7 @@ class EolReportAnalyticsView(View):
         responses = [
                 response['username'], 
                 students[response['username']]['email'], 
-                students[response['username']]['doc_id'],
+                students[response['username']]['indiv_id'],
                 raw_state['attempts']
                 ]
         aux_response = {}
@@ -532,11 +532,11 @@ class EolReportAnalyticsView(View):
             courseenrollment__mode='honor'
         ).order_by('username').values('id', 'username', 'email')
         user_id_list = enrolled_students.values_list('id', flat=True)
-        user_doc_id = get_user_id_doc_id_pairs(user_id_list)
-        user_doc_id_dict = {id: doc_id for id, doc_id in user_doc_id}
+        user_indiv_id_list = get_user_id_with_indiv_id_list(user_id_list)
+        user_indiv_id_dict = {id: indiv_id for id, indiv_id in user_indiv_id_list}
         for user in enrolled_students:
-            doc_id = user_doc_id_dict.get(user['id'], '')
-            students[user['username']] = {'email': user['email'], 'doc_id': doc_id}
+            indiv_id = user_indiv_id_dict.get(user['id'], '')
+            students[user['username']] = {'email': user['email'], 'indiv_id': indiv_id}
         return students
 
     def get_report_xblock(self, block_key, user_states, block):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_report_analytics",
-    version="1.0.0",
+    version="2.0.0",
     author="Oficina EOL UChile",
     author_email="eol-ing@uchile.cl",
     description=".",


### PR DESCRIPTION
Se actualiza eol_report_analytics para utilizar eol_sso en vez de uchileedxlogin.
Se reemplazan las menciones de doc_id por indiv_id.
Se actualizan los tests y sus requirements.